### PR TITLE
Use StorageAccessFramework on Android Lollipop and newer

### DIFF
--- a/app/src/main/java/org/wildstang/wildrank/androidv2/SyncUtilities.java
+++ b/app/src/main/java/org/wildstang/wildrank/androidv2/SyncUtilities.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.os.Build;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -19,7 +20,7 @@ public class SyncUtilities {
         return new File(getExternalRootDirectory(context)).exists();
     }
 
-    public static boolean useSAF(){
+    public static boolean useSAF() {
         return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
 
@@ -37,28 +38,39 @@ public class SyncUtilities {
     }
 
     public static String getExternalRootDirectory(Context context) {
-        if(databaseFolder == null)
-        {
+        if (databaseFolder == null) {
             //The location of the temp internal database used for sync should be
             //in the cache, since it is only needed for <1min at a time, and
             //created every time it is needed
-            if(useSAF())
-            {
+            if (useSAF()) {
                 File basePath = new File(context.getCacheDir() + File.separator + "externalDatabaseSync" + File.separator);
                 databaseFolder = basePath.getPath();
-            }
-            else {
+            } else {
                 return "/storage/usbdisk0/WildRank/cblite";
             }
         }
         return databaseFolder;
     }
 
-    public static void openFileChooser(Activity activity)
-    {
+    public static void openFileChooser(Activity activity) {
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*");
         activity.startActivityForResult(intent, SyncUtilities.REQUEST_CODE_OPEN);
+    }
+
+    public static boolean isOkAndOpen(int requestCode, int resultCode) {
+        return requestCode == REQUEST_CODE_OPEN && resultCode == Activity.RESULT_OK;
+    }
+
+    public static void copyExternalToInternal(InputStream externalDatabaseStream, Context context) throws IOException {
+        File internalDBCopyFolder = new File(SyncUtilities.getExternalRootDirectory(context) + File.separator + "wildrank.cblite2");
+        File internalDBCopyFile = new File(internalDBCopyFolder.getPath() + File.separator + "db.sqlite3");
+        if (!internalDBCopyFile.exists()) {
+            internalDBCopyFolder.mkdirs();
+            internalDBCopyFile.createNewFile();
+        }
+        OutputStream internalDBCopyStream = new FileOutputStream(internalDBCopyFile);
+        copyFromStreamToStream(externalDatabaseStream, internalDBCopyStream);
     }
 }

--- a/app/src/main/java/org/wildstang/wildrank/androidv2/SyncUtilities.java
+++ b/app/src/main/java/org/wildstang/wildrank/androidv2/SyncUtilities.java
@@ -1,10 +1,64 @@
 package org.wildstang.wildrank.androidv2;
 
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class SyncUtilities {
 
-    public static boolean isFlashDriveConnected() {
-        return new File(Utilities.getExternalRootDirectory()).exists();
+    public static final int REQUEST_CODE_OPEN = 42;
+    private static String databaseFolder = null;
+
+    public static boolean isFlashDriveConnected(Context context) {
+        return new File(getExternalRootDirectory(context)).exists();
+    }
+
+    public static boolean useSAF(){
+        return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+    }
+
+    public static void copyFromStreamToStream(InputStream in, OutputStream out) throws IOException {
+        byte[] buffer = new byte[1024];
+
+        int length;
+
+        while ((length = in.read(buffer)) > 0) {
+            out.write(buffer, 0, length);
+        }
+
+        in.close();
+        out.close();
+    }
+
+    public static String getExternalRootDirectory(Context context) {
+        if(databaseFolder == null)
+        {
+            //The location of the temp internal database used for sync should be
+            //in the cache, since it is only needed for <1min at a time, and
+            //created every time it is needed
+            if(useSAF())
+            {
+                File basePath = new File(context.getCacheDir() + File.separator + "externalDatabaseSync" + File.separator);
+                databaseFolder = basePath.getPath();
+            }
+            else {
+                return "/storage/usbdisk0/WildRank/cblite";
+            }
+        }
+        return databaseFolder;
+    }
+
+    public static void openFileChooser(Activity activity)
+    {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        activity.startActivityForResult(intent, SyncUtilities.REQUEST_CODE_OPEN);
     }
 }

--- a/app/src/main/java/org/wildstang/wildrank/androidv2/Utilities.java
+++ b/app/src/main/java/org/wildstang/wildrank/androidv2/Utilities.java
@@ -11,10 +11,6 @@ import java.util.Map;
 
 public class Utilities {
 
-    public static String getExternalRootDirectory() {
-        return "/storage/usbdisk0/WildRank/cblite";
-    }
-
     public static Object[] getRedTeamsFromMatchDocument(Document matchDocument) {
         Map<String, Object> properties = matchDocument.getProperties();
         Map<String, Object> alliances = (Map<String, Object>) properties.get("alliances");

--- a/app/src/main/java/org/wildstang/wildrank/androidv2/activities/AppSetupActivity.java
+++ b/app/src/main/java/org/wildstang/wildrank/androidv2/activities/AppSetupActivity.java
@@ -31,10 +31,7 @@ import org.wildstang.wildrank.androidv2.data.DatabaseManager;
 import org.wildstang.wildrank.androidv2.data.DatabaseManagerConstants;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -103,19 +100,11 @@ public class AppSetupActivity extends AppCompatActivity implements View.OnClickL
             setResult(Activity.RESULT_OK);
             startActivity(new Intent(this, HomeActivity.class));
             finish();
-        } else if (requestCode == SyncUtilities.REQUEST_CODE_OPEN && resultCode == Activity.RESULT_OK) {
+        } else if (SyncUtilities.isOkAndOpen(requestCode, resultCode)) {
             //Copy the external database to internal storage, then sync from it
             Uri externalDatabase = data.getData();
             try {
-                InputStream externalDatabaseStream = getContentResolver().openInputStream(externalDatabase);
-                File internalDBCopyFolder = new File(SyncUtilities.getExternalRootDirectory(getApplicationContext()) + File.separator + "wildrank.cblite2");
-                File internalDBCopyFile = new File(internalDBCopyFolder.getPath() + File.separator + "db.sqlite3");
-                if (!internalDBCopyFile.exists()) {
-                    internalDBCopyFolder.mkdirs();
-                    internalDBCopyFile.createNewFile();
-                }
-                OutputStream internalDBCopyStream = new FileOutputStream(internalDBCopyFile);
-                SyncUtilities.copyFromStreamToStream(externalDatabaseStream, internalDBCopyStream);
+                SyncUtilities.copyExternalToInternal(getContentResolver().openInputStream(externalDatabase), getApplicationContext());
                 new SetupTask().execute();
                 loadProgressBar.setVisibility(View.VISIBLE);
             } catch (IOException e) {

--- a/app/src/main/java/org/wildstang/wildrank/androidv2/activities/AppSetupActivity.java
+++ b/app/src/main/java/org/wildstang/wildrank/androidv2/activities/AppSetupActivity.java
@@ -3,6 +3,7 @@ package org.wildstang.wildrank.androidv2.activities;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -26,11 +27,14 @@ import com.couchbase.lite.android.AndroidContext;
 
 import org.wildstang.wildrank.androidv2.R;
 import org.wildstang.wildrank.androidv2.SyncUtilities;
-import org.wildstang.wildrank.androidv2.Utilities;
 import org.wildstang.wildrank.androidv2.data.DatabaseManager;
 import org.wildstang.wildrank.androidv2.data.DatabaseManagerConstants;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -54,12 +58,16 @@ public class AppSetupActivity extends AppCompatActivity implements View.OnClickL
     }
 
     private void beginDataLoad() {
-        if (!SyncUtilities.isFlashDriveConnected()) {
-            showExternalWarning();
+        if (SyncUtilities.useSAF()) {
+            SyncUtilities.openFileChooser(this);
         } else {
-            // Load data from the flash drive
-            new SetupTask().execute();
-            loadProgressBar.setVisibility(View.VISIBLE);
+            if (!SyncUtilities.isFlashDriveConnected(getApplicationContext())) {
+                showExternalWarning();
+            } else {
+                // Load data from the flash drive
+                new SetupTask().execute();
+                loadProgressBar.setVisibility(View.VISIBLE);
+            }
         }
     }
 
@@ -95,6 +103,25 @@ public class AppSetupActivity extends AppCompatActivity implements View.OnClickL
             setResult(Activity.RESULT_OK);
             startActivity(new Intent(this, HomeActivity.class));
             finish();
+        } else if (requestCode == SyncUtilities.REQUEST_CODE_OPEN && resultCode == Activity.RESULT_OK) {
+            //Copy the external database to internal storage, then sync from it
+            Uri externalDatabase = data.getData();
+            try {
+                InputStream externalDatabaseStream = getContentResolver().openInputStream(externalDatabase);
+                File internalDBCopyFolder = new File(SyncUtilities.getExternalRootDirectory(getApplicationContext()) + File.separator + "wildrank.cblite2");
+                File internalDBCopyFile = new File(internalDBCopyFolder.getPath() + File.separator + "db.sqlite3");
+                if (!internalDBCopyFile.exists()) {
+                    internalDBCopyFolder.mkdirs();
+                    internalDBCopyFile.createNewFile();
+                }
+                OutputStream internalDBCopyStream = new FileOutputStream(internalDBCopyFile);
+                SyncUtilities.copyFromStreamToStream(externalDatabaseStream, internalDBCopyStream);
+                new SetupTask().execute();
+                loadProgressBar.setVisibility(View.VISIBLE);
+            } catch (IOException e) {
+                e.printStackTrace();
+                Toast.makeText(this, e.getMessage() + " in " + getClass().getCanonicalName(), Toast.LENGTH_LONG).show();
+            }
         }
     }
 
@@ -105,11 +132,11 @@ public class AppSetupActivity extends AppCompatActivity implements View.OnClickL
             try {
                 Manager internalManager = DatabaseManager.getInstance(AppSetupActivity.this).getInternalManager();
 
-                // Custom Couchbase Manager that points to the flash drive
+                // Custom Couchbase Manager that points to the flash drive or internal copy of the external database
                 Context context = new AndroidContext(AppSetupActivity.this) {
                     @Override
                     public File getFilesDir() {
-                        return new File(Utilities.getExternalRootDirectory() + "/");
+                        return new File(SyncUtilities.getExternalRootDirectory(getApplicationContext()) + "/");
                     }
                 };
                 Manager externalManager = new Manager(context, Manager.DEFAULT_OPTIONS);
@@ -150,7 +177,6 @@ public class AppSetupActivity extends AppCompatActivity implements View.OnClickL
 
                     return true;
                 });
-
 
                 externalDatabase.close();
             } catch (Exception e) {

--- a/app/src/main/java/org/wildstang/wildrank/androidv2/activities/HomeActivity.java
+++ b/app/src/main/java/org/wildstang/wildrank/androidv2/activities/HomeActivity.java
@@ -1,6 +1,5 @@
 package org.wildstang.wildrank.androidv2.activities;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;

--- a/app/src/main/java/org/wildstang/wildrank/androidv2/activities/SyncActivity.java
+++ b/app/src/main/java/org/wildstang/wildrank/androidv2/activities/SyncActivity.java
@@ -1,7 +1,9 @@
 package org.wildstang.wildrank.androidv2.activities;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -22,6 +24,12 @@ import org.wildstang.wildrank.androidv2.SyncUtilities;
 import org.wildstang.wildrank.androidv2.data.DatabaseManager;
 import org.wildstang.wildrank.androidv2.data.DatabaseManagerConstants;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -34,6 +42,8 @@ public class SyncActivity extends AppCompatActivity {
     //TextView externalDatabaseContents;
     ProgressBar bar;
     TextView text;
+
+    private Uri externalFile = null;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -50,10 +60,37 @@ public class SyncActivity extends AppCompatActivity {
     }
 
     private void beginSync() {
-        if (!SyncUtilities.isFlashDriveConnected()) {
-            showDriveNotMountedWarning();
+        if (SyncUtilities.useSAF()) {
+            SyncUtilities.openFileChooser(this);
         } else {
-            new SyncTask().execute();
+            if (!SyncUtilities.isFlashDriveConnected(getApplicationContext())) {
+                showDriveNotMountedWarning();
+            } else {
+                new SyncTask().execute();
+            }
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == SyncUtilities.REQUEST_CODE_OPEN && resultCode == Activity.RESULT_OK) {
+            //Copy the external DB file the user selected to internal storage, then sync from it
+            externalFile = data.getData();
+            try {
+                InputStream externalFileStream = getContentResolver().openInputStream(externalFile);
+                File syncCBLiteDir = new File(SyncUtilities.getExternalRootDirectory(getApplicationContext()) + File.separator + "wildrank.cblite2");
+                File internalDBCopy = new File(syncCBLiteDir.getPath() + File.separator + "db.sqlite3");
+                if (!internalDBCopy.exists()) {
+                    syncCBLiteDir.mkdirs();
+                    internalDBCopy.createNewFile();
+                }
+                OutputStream internalDBCopyStream = new FileOutputStream(internalDBCopy);
+                SyncUtilities.copyFromStreamToStream(externalFileStream, internalDBCopyStream);
+                new SyncTask().execute();
+            } catch (IOException e) {
+                e.printStackTrace();
+                Toast.makeText(this, e.getMessage() + " in " + getClass().getCanonicalName(), Toast.LENGTH_LONG).show();
+            }
         }
     }
 
@@ -274,6 +311,24 @@ public class SyncActivity extends AppCompatActivity {
         }));
 
         externalDatabase.close();
+        if (SyncUtilities.useSAF()) {
+            //Copy the internal (synced) database back to the external location
+            if (externalFile != null) {
+                try {
+                    File internalCBLiteTempSyncDir = new File(SyncUtilities.getExternalRootDirectory(getApplicationContext()) + File.separator + "wildrank.cblite2");
+                    File internalDBCopy = new File(internalCBLiteTempSyncDir.getPath() + File.separator + "db.sqlite3");
+                    if (!internalDBCopy.exists()) {
+                        return;
+                    }
+                    InputStream internalDBStream = new FileInputStream(internalDBCopy);
+                    OutputStream externalDBStream = getContentResolver().openOutputStream(externalFile);
+                    SyncUtilities.copyFromStreamToStream(internalDBStream, externalDBStream);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    Toast.makeText(this, e.getMessage() + " in " + getClass().getCanonicalName(), Toast.LENGTH_LONG).show();
+                }
+            }
+        }
     }
 /*
     private void readDatabases() {

--- a/app/src/main/java/org/wildstang/wildrank/androidv2/activities/SyncActivity.java
+++ b/app/src/main/java/org/wildstang/wildrank/androidv2/activities/SyncActivity.java
@@ -1,6 +1,5 @@
 package org.wildstang.wildrank.androidv2.activities;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
@@ -26,7 +25,6 @@ import org.wildstang.wildrank.androidv2.data.DatabaseManagerConstants;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -73,19 +71,11 @@ public class SyncActivity extends AppCompatActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == SyncUtilities.REQUEST_CODE_OPEN && resultCode == Activity.RESULT_OK) {
+        if (SyncUtilities.isOkAndOpen(requestCode, resultCode)) {
             //Copy the external DB file the user selected to internal storage, then sync from it
             externalFile = data.getData();
             try {
-                InputStream externalFileStream = getContentResolver().openInputStream(externalFile);
-                File syncCBLiteDir = new File(SyncUtilities.getExternalRootDirectory(getApplicationContext()) + File.separator + "wildrank.cblite2");
-                File internalDBCopy = new File(syncCBLiteDir.getPath() + File.separator + "db.sqlite3");
-                if (!internalDBCopy.exists()) {
-                    syncCBLiteDir.mkdirs();
-                    internalDBCopy.createNewFile();
-                }
-                OutputStream internalDBCopyStream = new FileOutputStream(internalDBCopy);
-                SyncUtilities.copyFromStreamToStream(externalFileStream, internalDBCopyStream);
+                SyncUtilities.copyExternalToInternal(getContentResolver().openInputStream(externalFile), getApplicationContext());
                 new SyncTask().execute();
             } catch (IOException e) {
                 e.printStackTrace();

--- a/app/src/main/java/org/wildstang/wildrank/androidv2/data/DatabaseManager.java
+++ b/app/src/main/java/org/wildstang/wildrank/androidv2/data/DatabaseManager.java
@@ -14,8 +14,8 @@ import com.couchbase.lite.UnsavedRevision;
 import com.couchbase.lite.View;
 import com.couchbase.lite.android.AndroidContext;
 
+import org.wildstang.wildrank.androidv2.SyncUtilities;
 import org.wildstang.wildrank.androidv2.UserHelper;
-import org.wildstang.wildrank.androidv2.Utilities;
 
 import java.io.File;
 import java.io.IOException;
@@ -122,7 +122,7 @@ public class DatabaseManager {
             com.couchbase.lite.Context externalContext = new AndroidContext(context.getApplicationContext()) {
                 @Override
                 public File getFilesDir() {
-                    return new File(Utilities.getExternalRootDirectory() + "/");
+                    return new File(SyncUtilities.getExternalRootDirectory(context));
                 }
             };
             if (externalManager == null) {

--- a/app/src/main/res/layout/activity_app_setup.xml
+++ b/app/src/main/res/layout/activity_app_setup.xml
@@ -21,7 +21,7 @@
             android:layout_height="wrap_content"
             android:gravity="center"
             android:text="Welcome to WildRank!\n\nConnect a flash drive to set up the tablet."
-            android:textSize="48dp" />
+            android:textSize="40sp" />
 
         <ProgressBar
             android:layout_width="wrap_content"
@@ -34,7 +34,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Begin loading data"
-            android:textSize="48dp" />
+            android:textSize="32sp" />
 
         <ProgressBar
             android:id="@+id/progress_bar"


### PR DESCRIPTION
This solves #14 

Quick Summary: Wildrank uses the legacy File API for database access on external devices (the flashdrive used for Sync). Android 6 does not allow the use of this API outside of the App's data and cache directories, so external database sync is not possible (making the app impossible to setup).

This change uses the Storage Access Framework (introduced in KitKat, however this change only uses it in Lollipop and above) to allow the user to select the db.sqlite3 file. Once that file has been selected, it copies it to an internal directory in Wildrank's cache directory, and then performs the sync from there. If it is syncing changes back, it copies the external DB file to the cache directory, syncs, and then copies it back to the external file.

A plus to this change is that the app can now sync over many more providers (USB, SD card, Google Drive).